### PR TITLE
21 omit ses tag for single session data

### DIFF
--- a/conversion/config_dcm2bids_batch.py
+++ b/conversion/config_dcm2bids_batch.py
@@ -30,3 +30,7 @@ subjectlist = "subject_list.txt"
 
 # Run on local machine (run_local = True) or high performance cluster with slurm (run_local = False)
 run_local = False
+
+# If subject data are collected across multiple sessions, set to True. If single session, set to False.
+# https://bids-specification.readthedocs.io/en/v1.1.2/05-longitudinal-and-multi-site-studies.html
+multiple_sessions = False

--- a/conversion/dcm2bids_batch.py
+++ b/conversion/dcm2bids_batch.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 import config_dcm2bids_batch as cfg
 
+
 # Main function
 def main():
     """
@@ -19,21 +20,37 @@ def main():
 
 def batch_jobs(subject_list, path_dicoms, path_config, path_bidsdata):
     with open(subject_list) as file:
-        lines = file.readlines()  
+        lines = file.readlines()
     for line in lines:
         entry = line.strip()
         subjectdir = entry.split(",")[0]
         subject = entry.split(",")[1]
-        wave = entry.split(",")[2]
         subjectpath = os.path.join(path_dicoms, subjectdir)
         if os.path.isdir(subjectpath):
-            time.sleep(10)
             write_to_outputlog(subjectdir + os.linesep)
-            if cfg.run_local:
-                batch_cmd = 'dcm2bids -d {subjectpath} -s {wave} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber'.format(subjectpath=subjectpath,  wave=wave, subject=subject, path_config=path_config,  path_bidsdata=path_bidsdata)
+            if cfg.multiple_sessions:
+                wave = entry.split(",")[2]
+                if cfg.run_local:
+                    batch_cmd = 'dcm2bids -d {subjectpath} -s {wave} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber'.format(
+                        subjectpath=subjectpath, wave=wave, subject=subject, path_config=path_config,
+                        path_bidsdata=path_bidsdata)
+                else:
+                    batch_cmd = 'module load singularity; sbatch --job-name dcm2bids_{subjectdir} -A {account} --partition={partition} --time 00:60:00 --mem-per-cpu=2G --cpus-per-task=1 -o {logdir}/{subjectdir}_dcm2bids_output.txt -e {logdir}/{subjectdir}_dcm2bids_error.txt --wrap="singularity exec -B {path_dicoms} -B {path_bidsdata} -B {path_conversionfolder} {singularity_image} dcm2bids -d {subjectpath} -s {wave} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber"'.format(
+                        partition=cfg.partition, logdir=cfg.logdir, subjectdir=subjectdir, path_dicoms=cfg.path_dicoms,
+                        wave=wave, path_conversionfolder=cfg.path_conversionfolder, path_config=cfg.path_config,
+                        subject=subject, path_bidsdata=cfg.path_bidsdata, subjectpath=subjectpath,
+                        singularity_image=cfg.singularity_image, account=cfg.group)
             else:
-                batch_cmd = 'module load singularity; sbatch --job-name dcm2bids_{subjectdir} -A {account} --partition={partition} --time 00:60:00 --mem-per-cpu=2G --cpus-per-task=1 -o {logdir}/{subjectdir}_dcm2bids_output.txt -e {logdir}/{subjectdir}_dcm2bids_error.txt --wrap="singularity exec -B {path_dicoms} -B {path_bidsdata} -B {path_conversionfolder} {singularity_image} dcm2bids -d {subjectpath} -s {wave} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber"'.format(partition=cfg.partition, logdir=cfg.logdir, subjectdir=subjectdir, path_dicoms=cfg.path_dicoms, wave=wave, path_conversionfolder=cfg.path_conversionfolder, path_config=cfg.path_config, subject=subject, path_bidsdata=cfg.path_bidsdata, subjectpath=subjectpath, singularity_image=cfg.singularity_image, account=cfg.group)
+                if cfg.run_local:
+                    batch_cmd = 'dcm2bids -d {subjectpath} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber'.format(
+                        subjectpath=subjectpath, subject=subject, path_config=path_config,
+                        path_bidsdata=path_bidsdata)
+                else:
+                    batch_cmd = 'dcm2bids -d {subjectpath} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber'.format(
+                        subjectpath=subjectpath, subject=subject, path_config=path_config,
+                        path_bidsdata=path_bidsdata)
             subprocess.call([batch_cmd], shell=True)
+            time.sleep(10)
         else:
             write_to_errorlog(subjectdir + os.linesep)
 
@@ -43,7 +60,7 @@ def check_dicomdir(path_dicoms):
         write_to_errorlog("Incorrect dicom directory specified")
 
 
-def touch(path:str):
+def touch(path: str):
     """
     Create a new file
     
@@ -54,7 +71,7 @@ def touch(path:str):
         os.utime(path, None)
 
 
-def check_dirs(dir_fullpaths:list):
+def check_dirs(dir_fullpaths: list):
     """
     Check if a directory exists. If not, create it.
 
@@ -65,8 +82,8 @@ def check_dirs(dir_fullpaths:list):
         if not os.path.isdir(dir_fullpath):
             os.mkdir(dir_fullpath)
 
-            
-def create_logfiles(logfile_fullpaths:list):
+
+def create_logfiles(logfile_fullpaths: list):
     """
     Check if a logfile exists. If not, make one.
 

--- a/conversion/dcm2bids_batch.py
+++ b/conversion/dcm2bids_batch.py
@@ -27,6 +27,7 @@ def batch_jobs(subject_list, path_dicoms, path_config, path_bidsdata):
         subject = entry.split(",")[1]
         subjectpath = os.path.join(path_dicoms, subjectdir)
         if os.path.isdir(subjectpath):
+            time.sleep(10)
             write_to_outputlog(subjectdir + os.linesep)
             if cfg.multiple_sessions:
                 wave = entry.split(",")[2]
@@ -46,11 +47,12 @@ def batch_jobs(subject_list, path_dicoms, path_config, path_bidsdata):
                         subjectpath=subjectpath, subject=subject, path_config=path_config,
                         path_bidsdata=path_bidsdata)
                 else:
-                    batch_cmd = 'dcm2bids -d {subjectpath} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber'.format(
-                        subjectpath=subjectpath, subject=subject, path_config=path_config,
-                        path_bidsdata=path_bidsdata)
+                    batch_cmd = 'module load singularity; sbatch --job-name dcm2bids_{subjectdir} -A {account} --partition={partition} --time 00:60:00 --mem-per-cpu=2G --cpus-per-task=1 -o {logdir}/{subjectdir}_dcm2bids_output.txt -e {logdir}/{subjectdir}_dcm2bids_error.txt --wrap="singularity exec -B {path_dicoms} -B {path_bidsdata} -B {path_conversionfolder} {singularity_image} dcm2bids -d {subjectpath} -p {subject} -c {path_config} -o {path_bidsdata}  --forceDcm2niix --clobber"'.format(
+                        partition=cfg.partition, logdir=cfg.logdir, subjectdir=subjectdir, path_dicoms=cfg.path_dicoms,
+                        path_conversionfolder=cfg.path_conversionfolder, path_config=cfg.path_config,
+                        subject=subject, path_bidsdata=cfg.path_bidsdata, subjectpath=subjectpath,
+                        singularity_image=cfg.singularity_image, account=cfg.group)
             subprocess.call([batch_cmd], shell=True)
-            time.sleep(10)
         else:
             write_to_errorlog(subjectdir + os.linesep)
 


### PR DESCRIPTION
Add an option in the config_dcm2bids_batch.py file to set the data type as single session or multi-session. Update the dcm2bids_batch.py script to create the appropriate job submission commands based on dataset type (single or multi-session).